### PR TITLE
Small fix for compilation on OS-X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,18 @@ include $(GOROOT)/src/Make.inc
 
 TARG=github.com/edsrzf/mmap-go
 GOFILES=\
-	mmap.go\
+	mmap.go
 
 GOFILES_freebsd=\
-	mmap_unix.go\
+	mmap_linux.go\
+	mmap_unix.go
 
 GOFILES_darwin=\
-	mmap_unix.go\
+	mmap_darwin.go\
+	mmap_unix.go
 
 GOFILES_linux=\
+	mmap_linux.go\
 	mmap_unix.go
 
 GOFILES_windows=\

--- a/mmap_darwin.go
+++ b/mmap_darwin.go
@@ -1,0 +1,17 @@
+// Copyright 2011 Evan Shaw. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mmap
+
+import (
+	"syscall"
+)
+
+
+const (
+    MAP_ANONYMOUS = syscall.MAP_ANON
+)
+
+
+

--- a/mmap_linux.go
+++ b/mmap_linux.go
@@ -1,0 +1,15 @@
+// Copyright 2011 Evan Shaw. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mmap
+
+import (
+	"syscall"
+)
+
+const (
+    MAP_ANONYMOUS = syscall.MAP_ANONYMOUS
+)
+
+

--- a/mmap_unix.go
+++ b/mmap_unix.go
@@ -23,7 +23,7 @@ func mmap(len int, inprot, inflags, fd uintptr, off int64) ([]byte, os.Error) {
 		prot |= syscall.PROT_EXEC
 	}
 	if inflags&ANON != 0 {
-		flags |= syscall.MAP_ANONYMOUS
+		flags |= MAP_ANONYMOUS
 	}
 
 	b, errno := syscall.Mmap(int(fd), off, len, prot, flags)


### PR DESCRIPTION
Created two new files mmap_linux.go and mmap_darwin.go, which
define the new const mmap.MAP_ANONYMOUS according to the
platform-specific name (OS-X is MAP_ANON, linux is MAP_ANONYMOUS)
