### PR TITLE
mmap_windows.go: flush() now calls FlushFileBuffers()

### DIFF
--- a/mmap_windows.go
+++ b/mmap_windows.go
@@ -85,7 +85,7 @@ func flush(addr, len uintptr) error {
 		return errors.New("unknown base address")
 	}
 
-	errno = FlushFileBuffers(handle)
+	errno = syscall.FlushFileBuffers(handle)
 	return os.NewSyscallError("FlushFileBuffers", errno)
 }
 


### PR DESCRIPTION
to match msync(,,MS_SYNC) used in mmap_unix.go. Fixes #5.