### PR TITLE
explicit error when MapRegion offset is not multiple of pagesize

### DIFF
--- a/mmap.go
+++ b/mmap.go
@@ -54,6 +54,10 @@ func Map(f *os.File, prot, flags int) (MMap, error) {
 // If length < 0, the entire file will be mapped.
 // If ANON is set in flags, f is ignored.
 func MapRegion(f *os.File, length int, prot, flags int, offset int64) (MMap, error) {
+	if offset%int64(os.Getpagesize()) != 0 {
+		return nil, errors.New("offset parameter must be a multiple of the system's page size")
+	}
+
 	var fd uintptr
 	if flags&ANON == 0 {
 		fd = uintptr(f.Fd())

--- a/mmap_test.go
+++ b/mmap_test.go
@@ -138,6 +138,15 @@ func TestNonZeroOffset(t *testing.T) {
 	if err != nil {
 		t.Errorf("error mapping file: %s", err)
 	}
-	m.Unmap()
+	err = m.Unmap()
+	if err != nil {
+		t.Error(err)
+	}
+
+	m, err = MapRegion(fileobj, pageSize, RDONLY, 0, 1)
+	if err == nil {
+		t.Error("expect error because offset is not multiple of page size")
+	}
+
 	fileobj.Close()
 }


### PR DESCRIPTION
When start offset is not multiple of pagesize, it will still success at mapping, but will fail by `invalid argument` when unmap, which is not help user to debug.