### PR TITLE
Use golang.org/x/sys/unix on solaris

### DIFF
--- a/mmap.go
+++ b/mmap.go
@@ -80,37 +80,3 @@ func MapRegion(f *os.File, length int, prot, flags int, offset int64) (MMap, err
 func (m *MMap) header() *reflect.SliceHeader {
 	return (*reflect.SliceHeader)(unsafe.Pointer(m))
 }
-
-// Lock keeps the mapped region in physical memory, ensuring that it will not be
-// swapped out.
-func (m MMap) Lock() error {
-	dh := m.header()
-	return lock(dh.Data, uintptr(dh.Len))
-}
-
-// Unlock reverses the effect of Lock, allowing the mapped region to potentially
-// be swapped out.
-// If m is already unlocked, aan error will result.
-func (m MMap) Unlock() error {
-	dh := m.header()
-	return unlock(dh.Data, uintptr(dh.Len))
-}
-
-// Flush synchronizes the mapping's contents to the file's contents on disk.
-func (m MMap) Flush() error {
-	dh := m.header()
-	return flush(dh.Data, uintptr(dh.Len))
-}
-
-// Unmap deletes the memory mapped region, flushes any remaining changes, and sets
-// m to nil.
-// Trying to read or write any remaining references to m after Unmap is called will
-// result in undefined behavior.
-// Unmap should only be called on the slice value that was originally returned from
-// a call to Map. Calling Unmap on a derived slice may cause errors.
-func (m *MMap) Unmap() error {
-	dh := m.header()
-	err := unmap(dh.Data, uintptr(dh.Len))
-	*m = nil
-	return err
-}

--- a/mmap_solaris.go
+++ b/mmap_solaris.go
@@ -1,0 +1,68 @@
+// Copyright 2011 Evan Shaw. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build solaris
+
+package mmap
+
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func mmap(len int, inprot, inflags, fd uintptr, off int64) ([]byte, error) {
+	flags := unix.MAP_SHARED
+	prot := unix.PROT_READ
+	switch {
+	case inprot&COPY != 0:
+		prot |= unix.PROT_WRITE
+		flags = unix.MAP_PRIVATE
+	case inprot&RDWR != 0:
+		prot |= unix.PROT_WRITE
+	}
+	if inprot&EXEC != 0 {
+		prot |= unix.PROT_EXEC
+	}
+	if inflags&ANON != 0 {
+		flags |= unix.MAP_ANON
+	}
+
+	b, err := unix.Mmap(int(fd), off, len, prot, flags)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func flush(b []byte) error {
+	err := unix.Msync(b, unix.MS_SYNC)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func lock(b []byte) error {
+	err := unix.Mlock(b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func unlock(b []byte) error {
+	err := unix.Munlock(b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func unmap(b []byte) error {
+	err := unix.Munmap(b)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/mmap_sys.go
+++ b/mmap_sys.go
@@ -1,0 +1,37 @@
+// Copyright 2011 Evan Shaw. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build solaris
+
+package mmap
+
+// Lock keeps the mapped region in physical memory, ensuring that it will not be
+// swapped out.
+func (m MMap) Lock() error {
+	return lock([]byte(m))
+}
+
+// Unlock reverses the effect of Lock, allowing the mapped region to potentially
+// be swapped out.
+// If m is already unlocked, aan error will result.
+func (m MMap) Unlock() error {
+	return unlock([]byte(m))
+}
+
+// Flush synchronizes the mapping's contents to the file's contents on disk.
+func (m MMap) Flush() error {
+	return flush([]byte(m))
+}
+
+// Unmap deletes the memory mapped region, flushes any remaining changes, and sets
+// m to nil.
+// Trying to read or write any remaining references to m after Unmap is called will
+// result in undefined behavior.
+// Unmap should only be called on the slice value that was originally returned from
+// a call to Map. Calling Unmap on a derived slice may cause errors.
+func (m *MMap) Unmap() error {
+	err := unmap([]byte(*m))
+	*m = nil
+	return err
+}

--- a/mmap_syscall.go
+++ b/mmap_syscall.go
@@ -1,0 +1,41 @@
+// Copyright 2011 Evan Shaw. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !solaris
+
+package mmap
+
+// Lock keeps the mapped region in physical memory, ensuring that it will not be
+// swapped out.
+func (m MMap) Lock() error {
+	dh := m.header()
+	return lock(dh.Data, uintptr(dh.Len))
+}
+
+// Unlock reverses the effect of Lock, allowing the mapped region to potentially
+// be swapped out.
+// If m is already unlocked, aan error will result.
+func (m MMap) Unlock() error {
+	dh := m.header()
+	return unlock(dh.Data, uintptr(dh.Len))
+}
+
+// Flush synchronizes the mapping's contents to the file's contents on disk.
+func (m MMap) Flush() error {
+	dh := m.header()
+	return flush(dh.Data, uintptr(dh.Len))
+}
+
+// Unmap deletes the memory mapped region, flushes any remaining changes, and sets
+// m to nil.
+// Trying to read or write any remaining references to m after Unmap is called will
+// result in undefined behavior.
+// Unmap should only be called on the slice value that was originally returned from
+// a call to Map. Calling Unmap on a derived slice may cause errors.
+func (m *MMap) Unmap() error {
+	dh := m.header()
+	err := unmap(dh.Data, uintptr(dh.Len))
+	*m = nil
+	return err
+}

--- a/mmap_unix.go
+++ b/mmap_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin dragonfly freebsd linux openbsd solaris netbsd
+// +build darwin dragonfly freebsd linux openbsd !solaris netbsd
 
 package mmap
 

--- a/msync_unix.go
+++ b/msync_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin dragonfly freebsd linux openbsd solaris
+// +build darwin dragonfly freebsd linux openbsd !solaris
 
 package mmap
 


### PR DESCRIPTION
Avoid build issues on SmartOS (solaris, illumos)
undefined: syscall.Mmap
undefined: syscall.SYS_MLOCK
undefined: syscall.SYS_MUNLOCK
undefined: syscall.SYS_MUNMAP
undefined: syscall.SYS_MSYNC

Use unix. Mlock, Munlock, Munmap, Msync directly, to avoid
undefined: unix.SYS_MLOCK
undefined: unix.SYS_MUNLOCK
undefined: unix.SYS_MUNMAP
undefined: unix.SYS_MSYNC
https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/sys/syscall.h

unix.Msync for solaris after 2017-09-19
https://github.com/golang/sys/commit/b8ca6dd53df6c69d408877591c00f9ff76e8df88#diff-c1a0df1cd15dc5c6f51c742aa5a66b98