### PR TITLE
Added automated testing and go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 _obj
 _test
 testdata
+/.idea
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+os:
+  - windows
+  - linux
+  - osx
+go:
+  - 1.11.4
+env:
+  global:
+    - GO111MODULE=on
+install:
+  - go mod download
+  - go get github.com/mattn/goveralls
+script:
+  - go test -v -covermode=count -coverprofile=coverage.out -bench . -cpu 1,4
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN || true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 os:
-  - windows
   - linux
   - osx
+  - windows
 go:
   - 1.11.4
 env:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/edsrzf/mmap-go
+
+require golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6 h1:IcgEB62HYgAhX0Nd/QrVgZlxlcyxbGQHElLUhW2X4Fo=
+golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/mmap_windows.go
+++ b/mmap_windows.go
@@ -22,8 +22,9 @@ import (
 // We keep this map so that we can get back the original handle from the memory address.
 
 type addrinfo struct {
-	file    windows.Handle
-	mapview windows.Handle
+	file     windows.Handle
+	mapview  windows.Handle
+	writable bool
 }
 
 var handleLock sync.Mutex
@@ -32,13 +33,16 @@ var handleMap = map[uintptr]*addrinfo{}
 func mmap(len int, prot, flags, hfile uintptr, off int64) ([]byte, error) {
 	flProtect := uint32(windows.PAGE_READONLY)
 	dwDesiredAccess := uint32(windows.FILE_MAP_READ)
+	writable := false
 	switch {
 	case prot&COPY != 0:
 		flProtect = windows.PAGE_WRITECOPY
 		dwDesiredAccess = windows.FILE_MAP_COPY
+		writable = true
 	case prot&RDWR != 0:
 		flProtect = windows.PAGE_READWRITE
 		dwDesiredAccess = windows.FILE_MAP_WRITE
+		writable = true
 	}
 	if prot&EXEC != 0 {
 		flProtect <<= 4
@@ -67,8 +71,9 @@ func mmap(len int, prot, flags, hfile uintptr, off int64) ([]byte, error) {
 	}
 	handleLock.Lock()
 	handleMap[addr] = &addrinfo{
-		file:    windows.Handle(hfile),
-		mapview: h,
+		file:     windows.Handle(hfile),
+		mapview:  h,
+		writable: writable,
 	}
 	handleLock.Unlock()
 
@@ -96,8 +101,13 @@ func (m MMap) flush() error {
 		return errors.New("unknown base address")
 	}
 
-	errno = windows.FlushFileBuffers(handle.file)
-	return os.NewSyscallError("FlushFileBuffers", errno)
+	if handle.writable {
+		if err := windows.FlushFileBuffers(handle.file); err != nil {
+			return os.NewSyscallError("FlushFileBuffers", err)
+		}
+	}
+
+	return nil
 }
 
 func (m MMap) lock() error {


### PR DESCRIPTION
1. Added travis configuration to be able to run tests on Linux, macOS and Windows. Please see this [build run on TravisCI](https://travis-ci.org/blaubaer/mmap-go/builds/471348564) how it could look like. If you like it:
       1. Just go to [travis-ci.org](https://travis-ci.org/)
       2. Log in
       3. Grant TravisCI permissions to your repositories
       4. Activate TravisCI for your project `edsrzf/mmap-go` DONE! 😄 
2. Enable Golang Modules (https://github.com/golang/go/wiki/Modules) - In the next release just create a tag and other people can use this repo as regular Go Module. (without weird `GOPATH` or `vendor` stuff).  The tag has to match the pattern: `v[0-9]+\.[0-9]+\.[0-9]+`
3. Prevent `FlushFileBuffers` on Windows of Map is **not** `writable` - I need to do this because the tests where failing in Travis 😃 