### PR TITLE
Fix build on WASM

### DIFF
--- a/mmap_wasm.go
+++ b/mmap_wasm.go
@@ -1,0 +1,27 @@
+// Copyright 2024 Evan Shaw. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mmap
+
+import "syscall"
+
+func mmap(len int, inprot, inflags, fd uintptr, off int64) ([]byte, error) {
+	return nil, syscall.ENOTSUP
+}
+
+func (m MMap) flush() error {
+	return syscall.ENOTSUP
+}
+
+func (m MMap) lock() error {
+	return syscall.ENOTSUP
+}
+
+func (m MMap) unlock() error {
+	return syscall.ENOTSUP
+}
+
+func (m MMap) unmap() error {
+	return syscall.ENOTSUP
+}


### PR DESCRIPTION
This PR adds `mmap_wasm.go` file to allow dependent projects to compile for `wasm` architecture. It should resolve the issue #24.

The added file is mostly equivalent to `mmap_plan9.go` introduced in #25, except for the use of [`syscall.ENOTSUP`](https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/syscall/zerrors_linux_amd64.go;l=1280). This errno is used by the standard library such as [`syscall.AllThreadsSyscall`](https://pkg.go.dev/syscall#AllThreadsSyscall).