### PR TITLE
feat: support AIX

### DIFF
--- a/mmap_unix.go
+++ b/mmap_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin dragonfly freebsd linux openbsd solaris netbsd
+// +build darwin dragonfly freebsd linux openbsd solaris netbsd aix
 
 package mmap
 


### PR DESCRIPTION
AIX is also supported by golang and is unix compatible in mmap syntax, so we can easily support it by adding a build tag for it.