### PR TITLE
feat: add reader that works around SIGBUS

### DIFF
--- a/mmap.go
+++ b/mmap.go
@@ -15,6 +15,7 @@
 package mmap
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"reflect"
@@ -114,4 +115,13 @@ func (m *MMap) Unmap() error {
 	err := m.unmap()
 	*m = nil
 	return err
+}
+
+// Reader returns a reader on the memory mapped region that handles potentially occurring
+// faults (such as page read errors).
+func (m MMap) Reader() *FaultReader {
+	return &FaultReader{
+		mmap:   m,
+		reader: bytes.NewReader(m),
+	}
 }

--- a/reader.go
+++ b/reader.go
@@ -1,0 +1,83 @@
+package mmap
+
+import (
+	"bytes"
+	"io"
+	"runtime"
+	"runtime/debug"
+)
+
+type FaultReader struct {
+	mmap   MMap
+	reader *bytes.Reader
+}
+
+type addressFault interface {
+	runtime.Error
+	Addr() uintptr
+}
+
+func (f *FaultReader) Len() int {
+	return f.reader.Len()
+}
+
+func (f *FaultReader) Size() int64 {
+	return f.reader.Size()
+}
+
+func (f *FaultReader) Read(b []byte) (n int, err error) {
+	if fault := f.handleFaults(func() {
+		n, err = f.reader.Read(b)
+	}); fault != nil {
+		err = fault
+	}
+	return
+}
+
+func (f *FaultReader) ReadAt(b []byte, off int64) (n int, err error) {
+	if fault := f.handleFaults(func() {
+		n, err = f.reader.ReadAt(b, off)
+	}); fault != nil {
+		err = fault
+	}
+	return
+}
+
+func (f *FaultReader) Seek(offset int64, whence int) (int64, error) {
+	return f.reader.Seek(offset, whence)
+}
+
+func (f *FaultReader) WriteTo(w io.Writer) (n int64, err error) {
+	if fault := f.handleFaults(func() {
+		n, err = f.reader.WriteTo(w)
+	}); fault != nil {
+		err = fault
+	}
+	return
+}
+
+func (f *FaultReader) handleFaults(forFunction func()) (err error) {
+	previousSetting := debug.SetPanicOnFault(true)
+	defer func() {
+		debug.SetPanicOnFault(previousSetting)
+		if panicErr := recover(); panicErr != nil {
+			fault, isAddressFault := panicErr.(addressFault)
+			if !isAddressFault {
+				panic(panicErr)
+			}
+			address := fault.Addr()
+			mappedAddr, mappedLen := f.mmap.addrLen()
+			if mappedAddr <= address && address < mappedAddr+mappedLen {
+				// Fault while reading our data
+				err = fault
+			} else {
+				// Forward panic
+				// This is not perfect because we potentially downgraded a runtime fault to a panic, but Golang does not
+				// allow triggering a runtime fault directly
+				panic(fault)
+			}
+		}
+	}()
+	forFunction()
+	return nil
+}


### PR DESCRIPTION
mmap regions are "dangerous" in so far that if the content is not available (e.g. because the underlying file was truncated), they cause a SIGBUS. SIGBUS then, in return, causes a golang runtime fault, causing the program to forcefully exit.

Golang has support for handling SIGBUS (and the Windows equivalent) with https://pkg.go.dev/runtime/debug#SetPanicOnFault. By setting this, the go routine where it is set only triggers a panic instead of a runtime fault.

This request adds a reader that can be used to read from the mmapped region in a SIGBUS safe way by using SetPanicOnFault and resetting it afterwards.